### PR TITLE
Adding Registration Journey to Submission and submission events

### DIFF
--- a/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/ISubmissionStatusClient.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/ISubmissionStatusClient.cs
@@ -38,7 +38,7 @@ public interface ISubmissionStatusClient
 
     Task<SubmissionHistoryEventsResponse> GetSubmissionPeriodHistory(Guid submissionId, string queryString);
 
-    Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType);
+    Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? registrationJourney);
 
     Task<RegistrationApplicationDetails?> GetRegistrationApplicationDetails(string queryString);
 

--- a/WebApiGateway/WebApiGateway.Api/Clients/SubmissionStatusClient.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/SubmissionStatusClient.cs
@@ -308,7 +308,7 @@ public class SubmissionStatusClient(
         return results;
     }
 
-    public async Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType)
+    public async Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? registrationJourney)
     {
         await ConfigureHttpClientAsync();
 
@@ -322,6 +322,11 @@ public class SubmissionStatusClient(
         if (year is not null)
         {
             endpoint += $"&Year={year}";
+        }
+
+        if (registrationJourney is not null)
+        {
+            endpoint += $"&RegistrationJourney={registrationJourney}";
         }
 
         var response = await httpClient.GetAsync(endpoint);

--- a/WebApiGateway/WebApiGateway.Api/Clients/SubmissionStatusQueryBuilder.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/SubmissionStatusQueryBuilder.cs
@@ -2,7 +2,7 @@
 
 namespace WebApiGateway.Api.Clients;
 
-public class SubmissionStatusQueryBuilder
+public static class SubmissionStatusQueryBuilder
 {
     public static string BuildSubmissionsEndpointQueryString(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? registrationJourney)
     {

--- a/WebApiGateway/WebApiGateway.Api/Clients/SubmissionStatusQueryBuilder.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/SubmissionStatusQueryBuilder.cs
@@ -1,0 +1,28 @@
+﻿using WebApiGateway.Core.Enumeration;
+
+namespace WebApiGateway.Api.Clients;
+
+public class SubmissionStatusQueryBuilder
+{
+    public static string BuildSubmissionsEndpointQueryString(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? registrationJourney)
+    {
+        var endpoint = $"submissions/submissions?Type={submissionType}&OrganisationId={organisationId}";
+
+        if (complianceSchemeId is not null && complianceSchemeId != Guid.Empty)
+        {
+            endpoint += $"&ComplianceSchemeId={complianceSchemeId}";
+        }
+
+        if (year is not null)
+        {
+            endpoint += $"&Year={year}";
+        }
+
+        if (registrationJourney is not null)
+        {
+            endpoint += $"&RegistrationJourney={registrationJourney}";
+        }
+
+        return endpoint;
+    }
+}

--- a/WebApiGateway/WebApiGateway.Api/Controllers/SubmissionController.cs
+++ b/WebApiGateway/WebApiGateway.Api/Controllers/SubmissionController.cs
@@ -68,7 +68,8 @@ public class SubmissionController(
             organisationId,
             request.ComplianceSchemeId,
             request.Year,
-            request.Type);
+            request.Type,
+            request.RegistrationJourney);
 
         return new OkObjectResult(submissions);
     }

--- a/WebApiGateway/WebApiGateway.Api/Handlers/AccountServiceAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/AccountServiceAuthorisationHandler.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Headers;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Options;
-using Microsoft.Identity.Web;
 using WebApiGateway.Core.Options;
 
 namespace WebApiGateway.Api.Handlers;

--- a/WebApiGateway/WebApiGateway.Api/Handlers/AntivirusApiAuthorizationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/AntivirusApiAuthorizationHandler.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Headers;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Options;
-using Microsoft.Identity.Web;
 using WebApiGateway.Core.Options;
 
 namespace WebApiGateway.Api.Handlers;

--- a/WebApiGateway/WebApiGateway.Api/Handlers/PrnServiceAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/PrnServiceAuthorisationHandler.cs
@@ -3,7 +3,6 @@ using System.Net.Http.Headers;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.Extensions.Options;
-using Microsoft.Identity.Web;
 using WebApiGateway.Core.Options;
 
 namespace WebApiGateway.Api.Handlers;

--- a/WebApiGateway/WebApiGateway.Api/Services/Interfaces/ISubmissionService.cs
+++ b/WebApiGateway/WebApiGateway.Api/Services/Interfaces/ISubmissionService.cs
@@ -32,7 +32,7 @@ public interface ISubmissionService
 
     Task<List<SubmissionHistoryResponse>> GetSubmissionPeriodHistory(Guid submissionId, string queryString);
 
-    Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType);
+    Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? requestRegistrationJourney);
 
     Task<string> GetFileBlobNameAsync(Guid submissionId, Guid fileId);
 }

--- a/WebApiGateway/WebApiGateway.Api/Services/Interfaces/ISubmissionService.cs
+++ b/WebApiGateway/WebApiGateway.Api/Services/Interfaces/ISubmissionService.cs
@@ -32,7 +32,7 @@ public interface ISubmissionService
 
     Task<List<SubmissionHistoryResponse>> GetSubmissionPeriodHistory(Guid submissionId, string queryString);
 
-    Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? requestRegistrationJourney);
+    Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? registrationJourney);
 
     Task<string> GetFileBlobNameAsync(Guid submissionId, Guid fileId);
 }

--- a/WebApiGateway/WebApiGateway.Api/Services/SubmissionService.cs
+++ b/WebApiGateway/WebApiGateway.Api/Services/SubmissionService.cs
@@ -93,7 +93,8 @@ public class SubmissionService(
                 PaidAmount = applicationPayload.PaidAmount,
                 PaymentMethod = applicationPayload.PaymentMethod,
                 PaymentStatus = applicationPayload.PaymentStatus,
-                IsResubmission = applicationPayload.IsResubmission
+                IsResubmission = applicationPayload.IsResubmission,
+                RegistrationJourney = applicationPayload.RegistrationJourney,
             };
 
             await submissionStatusClient.CreateRegistrationFeePaymentEventAsync(feePaymentEvent, submissionId);
@@ -107,7 +108,8 @@ public class SubmissionService(
                 ApplicationReferenceNumber = applicationPayload.ApplicationReferenceNumber,
                 ComplianceSchemeId = applicationPayload.ComplianceSchemeId,
                 SubmissionDate = DateTime.UtcNow,
-                IsResubmission = applicationPayload.IsResubmission
+                IsResubmission = applicationPayload.IsResubmission,
+                RegistrationJourney = applicationPayload.RegistrationJourney,
             };
 
             await submissionStatusClient.CreateApplicationSubmittedEventAsync(submittedEvent, submissionId);
@@ -131,9 +133,9 @@ public class SubmissionService(
         return FormatSubmissionHistoryData(submissionHistory);
     }
 
-    public async Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType)
+    public async Task<List<SubmissionGetResponse>> GetSubmissionsByFilter(Guid organisationId, Guid? complianceSchemeId, int? year, SubmissionType submissionType, string? registrationJourney)
     {
-        return await submissionStatusClient.GetSubmissionsByFilter(organisationId, complianceSchemeId, year, submissionType);
+        return await submissionStatusClient.GetSubmissionsByFilter(organisationId, complianceSchemeId, year, submissionType, registrationJourney);
     }
 
     /// <summary>

--- a/WebApiGateway/WebApiGateway.Core/Models/Events/RegistrationApplicationSubmittedEvent.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Events/RegistrationApplicationSubmittedEvent.cs
@@ -17,4 +17,6 @@ public class RegistrationApplicationSubmittedEvent : AbstractEvent
     public DateTime? SubmissionDate { get; set; }
 
     public bool? IsResubmission { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Events/RegistrationFeePaymentEvent.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Events/RegistrationFeePaymentEvent.cs
@@ -19,4 +19,6 @@ public class RegistrationFeePaymentEvent : AbstractEvent
     public string PaidAmount { get; set; }
 
     public bool? IsResubmission { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submission/AbstractSubmission.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submission/AbstractSubmission.cs
@@ -36,4 +36,6 @@ public abstract class AbstractSubmission
     public bool HasWarnings { get; set; }
 
     public string? AppReferenceNumber { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submission/CreateSubmission.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submission/CreateSubmission.cs
@@ -17,4 +17,6 @@ public class CreateSubmission
     public Guid? ComplianceSchemeId { get; set; }
 
     public bool? IsResubmission { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submission/RegistrationApplicationPayload.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submission/RegistrationApplicationPayload.cs
@@ -21,4 +21,6 @@ public class RegistrationApplicationPayload
     public SubmissionType SubmissionType { get; set; }
 
     public bool? IsResubmission { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submission/SubmissionPayload.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submission/SubmissionPayload.cs
@@ -12,4 +12,6 @@ public class SubmissionPayload
     public string? AppReferenceNumber { get; set; }
 
     public bool? IsResubmission { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submissions/SubmissionGetRequest.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submissions/SubmissionGetRequest.cs
@@ -11,4 +11,6 @@ public class SubmissionGetRequest
     public int? Year { get; set; }
 
     public SubmissionType Type { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submissions/SubmissionGetResponse.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submissions/SubmissionGetResponse.cs
@@ -14,4 +14,6 @@ public class SubmissionGetResponse
 
     [JsonPropertyName("Year")]
     public int Year { get; set; }
+
+    public string? RegistrationJourney { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/SubmissionStatusClientTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/SubmissionStatusClientTests.cs
@@ -627,7 +627,7 @@ public class SubmissionStatusClientTests
         _httpMessageHandlerMock.RespondWith(HttpStatusCode.OK, submissions.ToJsonContent());
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, year, submissionType);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, year, submissionType, null);
 
         // Assert
         result.Should().BeEquivalentTo(submissions);
@@ -668,7 +668,7 @@ public class SubmissionStatusClientTests
         _httpMessageHandlerMock.RespondWith(HttpStatusCode.OK, submissions.ToJsonContent());
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, Guid.Empty, year, submissionType);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, Guid.Empty, year, submissionType, null);
 
         // Assert
         result.Should().BeEquivalentTo(submissions);
@@ -709,7 +709,7 @@ public class SubmissionStatusClientTests
         _httpMessageHandlerMock.RespondWith(HttpStatusCode.OK, submissions.ToJsonContent());
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType, null);
 
         // Assert
         result.Should().BeEquivalentTo(submissions);

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/SubmissionStatusClientTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/SubmissionStatusClientTests.cs
@@ -65,6 +65,26 @@ public class SubmissionStatusClientTests
     }
 
     [TestMethod]
+    public async Task ValidateAbsoluteUrlTest()
+    {
+        var uri = SubmissionStatusClient.ValidateUrl("https://example.com");
+        Assert.IsTrue(uri.IsAbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task ValidateRelativeUrlTest()
+    {
+        var uri = SubmissionStatusClient.ValidateUrl("/foo/bar/baz.html");
+        Assert.IsFalse(uri.IsAbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task ValidateInvalidUrlTests()
+    {
+        Assert.ThrowsException<InvalidOperationException>(() => SubmissionStatusClient.ValidateUrl("ftp://example.com"));
+    }
+
+    [TestMethod]
     public async Task CreateEventAsync_DoesNotThrowException_WhenHttpClientResponseIsCreated()
     {
         // Arrange
@@ -683,6 +703,7 @@ public class SubmissionStatusClientTests
         var organisationId = Guid.NewGuid();
         var complianceSchemaId = Guid.NewGuid();
         var submissionType = SubmissionType.Producer;
+        var registrationJourney = "TestMcRegistrationFace";
 
         var submissions = new List<SubmissionGetResponse>
         {
@@ -709,11 +730,21 @@ public class SubmissionStatusClientTests
         _httpMessageHandlerMock.RespondWith(HttpStatusCode.OK, submissions.ToJsonContent());
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType, null);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType, registrationJourney);
 
         // Assert
         result.Should().BeEquivalentTo(submissions);
         result.Should().HaveCount(3);
+    }
+
+    [TestMethod]
+    public void CanBuildExpectedSubmissionsEndpointQueryString()
+    {
+        var organisationId = Guid.NewGuid();
+        var complianceSchemaId = Guid.NewGuid();
+        var submissionType = SubmissionType.Producer;
+        var x = SubmissionStatusQueryBuilder.BuildSubmissionsEndpointQueryString(organisationId, complianceSchemaId, 2025, submissionType, "registr4tionJourney");
+        x.Should().BeEquivalentTo($"submissions/submissions?Type=Producer&OrganisationId={organisationId}&ComplianceSchemeId={complianceSchemaId}&Year=2025&RegistrationJourney=registr4tionJourney");
     }
 
     [TestMethod]

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/SubmissionControllerTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/SubmissionControllerTests.cs
@@ -187,7 +187,8 @@ public class SubmissionControllerTests
             organisationId,
             complianceSchemaId,
             year,
-            submissionType))
+            submissionType,
+            null))
             .ReturnsAsync(submissions);
 
         // Act
@@ -206,7 +207,8 @@ public class SubmissionControllerTests
             organisationId,
             complianceSchemaId,
             year,
-            submissionType),
+            submissionType,
+            null),
             Times.Once);
     }
 

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Services/SubmissionServiceTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Services/SubmissionServiceTests.cs
@@ -528,11 +528,11 @@ public class SubmissionServiceTests
             .ToList();
 
         _submissionStatusClientMock
-            .Setup(x => x.GetSubmissionsByFilter(organisationId, complianceSchemaId, year, submissionType))
+            .Setup(x => x.GetSubmissionsByFilter(organisationId, complianceSchemaId, year, submissionType, null))
             .ReturnsAsync(submissionsResponse);
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, year, submissionType);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, year, submissionType, null);
 
         // Assert
         result.Should().NotBeNull();
@@ -552,11 +552,11 @@ public class SubmissionServiceTests
             .ToList();
 
         _submissionStatusClientMock
-            .Setup(x => x.GetSubmissionsByFilter(organisationId, Guid.Empty, year, submissionType))
+            .Setup(x => x.GetSubmissionsByFilter(organisationId, Guid.Empty, year, submissionType, "Journey"))
             .ReturnsAsync(submissionsResponse);
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, Guid.Empty, year, submissionType);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, Guid.Empty, year, submissionType, "Journey");
 
         // Assert
         result.Should().NotBeNull();
@@ -576,11 +576,11 @@ public class SubmissionServiceTests
             .ToList();
 
         _submissionStatusClientMock
-            .Setup(x => x.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType))
+            .Setup(x => x.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType, "testJourney"))
             .ReturnsAsync(submissionsResponse);
 
         // Act
-        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType);
+        var result = await _systemUnderTest.GetSubmissionsByFilter(organisationId, complianceSchemaId, null, submissionType, "testJourney");
 
         // Assert
         result.Should().NotBeNull();


### PR DESCRIPTION
Adding registration Journey property to Submissions and to Submission Events for future filtering abilities as some endpoints to not take Submission ID, only Orgnisation or Compliance Scheme Ids and therefore for a given period could get multiple results if not filtering by the registration journey Large|Small