### PR TITLE
SUB-149, DD. Added registration year to submission response.

### DIFF
--- a/WebApiGateway/WebApiGateway.Core/Models/Submission/AbstractSubmission.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submission/AbstractSubmission.cs
@@ -38,4 +38,6 @@ public abstract class AbstractSubmission
     public string? AppReferenceNumber { get; set; }
 
     public string? RegistrationJourney { get; set; }
+    
+    public int? RegistrationYear { get; set; }
 }

--- a/WebApiGateway/WebApiGateway.Core/Models/Submissions/SubmissionGetResponse.cs
+++ b/WebApiGateway/WebApiGateway.Core/Models/Submissions/SubmissionGetResponse.cs
@@ -16,4 +16,6 @@ public class SubmissionGetResponse
     public int Year { get; set; }
 
     public string? RegistrationJourney { get; set; }
+    
+    public int? RegistrationYear { get; set; }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/SUB-149

* Added `registrationYear` to submission responses

<img width="1428" height="1141" alt="image" src="https://github.com/user-attachments/assets/ea6a587f-d5b8-4049-8a39-710fd3480261" />
