### PR TITLE
SUB-39: Modified the "IsResubmissionDataSynced" check to re-use the "GetPackagingResubmissionMemberDetails" method in the CommonDataAPI

### DIFF
--- a/WebApiGateway/WebApiGateway.Api/Services/PackagingResubmissionApplicationService.cs
+++ b/WebApiGateway/WebApiGateway.Api/Services/PackagingResubmissionApplicationService.cs
@@ -25,12 +25,15 @@ public class PackagingResubmissionApplicationService(
             {
                 var fileId = applicationDetail.LastSubmittedFile.FileId.Value;
                 var fileSyncTask = commondataClient.GetPackagingResubmissionFileSyncStatusFromSynapse(fileId);
-                var dataSyncTask = commondataClient.GetPackagingResubmissionSyncStatusFromSynapse(fileId);
+                var dataSyncTask = commondataClient.GetPackagingResubmissionMemberDetails((Guid)applicationDetail.SubmissionId, null); // SUB-39: ComplianceSchemeId not need for this check for the presence of data.
                 
                 await Task.WhenAll(fileSyncTask, dataSyncTask);
                 
                 applicationDetail.SynapseResponse.IsFileSynced = fileSyncTask.Result;
-                applicationDetail.SynapseResponse.IsResubmissionDataSynced = dataSyncTask.Result;
+                
+                // SUB-39: Underlying stored procedure checks for an entry in the "apps.SubmissionsSummaries" table. This is populated towards the end of the pip_recyclers stage in
+                // the pip_wrapper import pipeline. This indicates that the sync process has completed as far as this check is concerned; otherwise an error message is returned by the Common Data API.
+                applicationDetail.SynapseResponse.IsResubmissionDataSynced = string.IsNullOrEmpty(dataSyncTask.Result.ErrorMessage); 
             }
         }
 

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Services/PackagingResubmissionApplicationServiceTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Services/PackagingResubmissionApplicationServiceTests.cs
@@ -39,38 +39,16 @@ public class PackagingResubmissionApplicationServiceTests
         _submissionStatusClientMock.Verify(client => client.GetPackagingResubmissionApplicationDetails(It.IsAny<string>()), Times.Once);
     }
 
-    [TestMethod]
-    public async Task GetPackagingResubmissionApplicationDetails_ShouldReturnResult_WhenSubmissionStatusClientReturnsNotNull()
-    {
-        // Arrange
-        _submissionStatusClientMock.Setup(x => x.GetPackagingResubmissionApplicationDetails(It.IsAny<string>()))
-            .ReturnsAsync([
-                new PackagingResubmissionApplicationDetails
-                {
-                    IsSubmitted = true,
-                    LastSubmittedFile = new PackagingResubmissionApplicationDetails.LastSubmittedFileDetails
-                        { FileId = Guid.NewGuid() }
-                }
-            ]);
-
-        _commondataClientMock.Setup(x => x.GetPackagingResubmissionFileSyncStatusFromSynapse(It.IsAny<Guid>())).ReturnsAsync(It.IsAny<bool>());
-        _commondataClientMock.Setup(x => x.GetPackagingResubmissionSyncStatusFromSynapse(It.IsAny<Guid>())).ReturnsAsync(It.IsAny<bool>());
-
-        // Act
-        var result = await _service.GetPackagingResubmissionApplicationDetails("test");
-
-        // Assert
-        result.Should().NotBeNull();
-        _commondataClientMock.Verify(client => client.GetPackagingResubmissionFileSyncStatusFromSynapse(It.IsAny<Guid>()), Times.Once);
-        _commondataClientMock.Verify(client => client.GetPackagingResubmissionSyncStatusFromSynapse(It.IsAny<Guid>()), Times.Once);
-    }
-    
     [DataTestMethod]
-    [DataRow(false, false)]
-    [DataRow(true, false)]
-    [DataRow(false, true)]
-    [DataRow(true, true)]
-    public async Task GetPackagingResubmissionApplicationDetails_ShouldReturnExpectedSyncStatusResults_WhenSubmissionStatusClientReturnsNotNull(bool fileSyncStatus, bool dataSyncStatus)
+    [DataRow(false, "", true)]
+    [DataRow(true, "", true)]
+    [DataRow(false, " ", false)]
+    [DataRow(true, " ", false)]
+    [DataRow(false, null, true)]
+    [DataRow(true, null, true)]
+    [DataRow(false, "Error", false)]
+    [DataRow(true, "Error", false)]
+    public async Task GetPackagingResubmissionApplicationDetails_ShouldReturnExpectedSyncStatusResults_WhenSubmissionStatusClientReturnsAValidResponse(bool fileSyncStatus, string errorMessage, bool syncComplete)
     {
         // Arrange
         _submissionStatusClientMock.Setup(x => x.GetPackagingResubmissionApplicationDetails(It.IsAny<string>()))
@@ -79,12 +57,17 @@ public class PackagingResubmissionApplicationServiceTests
                 {
                     IsSubmitted = true,
                     LastSubmittedFile = new PackagingResubmissionApplicationDetails.LastSubmittedFileDetails
-                        { FileId = Guid.NewGuid() }
+                        { FileId = Guid.NewGuid() },
+                    SubmissionId = Guid.NewGuid()
                 }
             ]);
+
+        var testResponse = new PackagingResubmissionMemberResponse { MemberCount = 1, ErrorMessage = errorMessage, ReferenceNumber = "124356" };
+        _commondataClientMock
+            .Setup(x => x.GetPackagingResubmissionMemberDetails(It.IsAny<Guid>(), null))
+            .ReturnsAsync(testResponse);
 
         _commondataClientMock.Setup(x => x.GetPackagingResubmissionFileSyncStatusFromSynapse(It.IsAny<Guid>())).ReturnsAsync(fileSyncStatus);
-        _commondataClientMock.Setup(x => x.GetPackagingResubmissionSyncStatusFromSynapse(It.IsAny<Guid>())).ReturnsAsync(dataSyncStatus);
 
         // Act
         var result = await _service.GetPackagingResubmissionApplicationDetails("test");
@@ -94,9 +77,9 @@ public class PackagingResubmissionApplicationServiceTests
         result[0].Should().NotBeNull();
         result[0]?.SynapseResponse.Should().NotBeNull();
         result[0]?.SynapseResponse.IsFileSynced.Should().Be(fileSyncStatus);
-        result[0]?.SynapseResponse.IsResubmissionDataSynced.Should().Be(dataSyncStatus);
+        result[0]?.SynapseResponse.IsResubmissionDataSynced.Should().Be(syncComplete);
         _commondataClientMock.Verify(client => client.GetPackagingResubmissionFileSyncStatusFromSynapse(It.IsAny<Guid>()), Times.Once);
-        _commondataClientMock.Verify(client => client.GetPackagingResubmissionSyncStatusFromSynapse(It.IsAny<Guid>()), Times.Once);
+        _commondataClientMock.Verify(client => client.GetPackagingResubmissionMemberDetails(It.IsAny<Guid>(), null), Times.Once);
     }
 
     [TestMethod]


### PR DESCRIPTION
SUB-39: Modified the "IsResubmissionDataSynced" check to re-use the "GetPackagingResubmissionMemberDetails" method in the CommonDataAPI. There are 3 tables populated by the pip_recyclers child pipeline of pip_wrapper. This method calls down to a stored procedure that checks for an entry in the final table to be populated, "apps.SubmissionsSummaries". Reworked tests accordingly.