### PR TITLE
MO-121: Integrate waste-obligations running in CDP for compliance declarations

### DIFF
--- a/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/IWasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/IWasteObligationsProxy.cs
@@ -2,5 +2,5 @@
 
 public interface IWasteObligationsProxy
 {
-    Task<string?> Get(string requestUri, CancellationToken cancellationToken);
+    Task<string?> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken);
 }

--- a/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/IWasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/IWasteObligationsProxy.cs
@@ -2,5 +2,5 @@
 
 public interface IWasteObligationsProxy
 {
-    Task<string?> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken);
+    Task<string?> GetComplianceDeclarations(int obligationYear, CancellationToken cancellationToken);
 }

--- a/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/IWasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/Interfaces/IWasteObligationsProxy.cs
@@ -1,0 +1,6 @@
+﻿namespace WebApiGateway.Api.Clients.Interfaces;
+
+public interface IWasteObligationsProxy
+{
+    Task<string?> Get(string requestUri, CancellationToken cancellationToken);
+}

--- a/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
@@ -1,4 +1,5 @@
-﻿using WebApiGateway.Api.Clients.Interfaces;
+﻿using System.Net;
+using WebApiGateway.Api.Clients.Interfaces;
 
 namespace WebApiGateway.Api.Clients;
 
@@ -12,6 +13,14 @@ public class WasteObligationsProxy(HttpClient httpClient) : IWasteObligationsPro
             cancellationToken);
     }
 
-    private async Task<string?> Get(string requestUri, CancellationToken cancellationToken) =>
-        await httpClient.GetStringAsync(requestUri, cancellationToken);
+    private async Task<string?> Get(string requestUri, CancellationToken cancellationToken)
+    {
+        var response = await httpClient.GetAsync(requestUri, cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        return await response.Content.ReadAsStringAsync(cancellationToken);
+    }
 }

--- a/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
@@ -4,8 +4,14 @@ namespace WebApiGateway.Api.Clients;
 
 public class WasteObligationsProxy(HttpClient httpClient) : IWasteObligationsProxy
 {
-    public async Task<string?> Get(string requestUri, CancellationToken cancellationToken)
+    public async Task<string?> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken)
     {
-        return await httpClient.GetStringAsync(requestUri, cancellationToken);
+        // See WasteObligationsAuthorisationHandler for :organisationId replacement 
+        return await Get(
+            $"/organisations/:organisationId/compliance-declarations?obligationYear={obligationYear}",
+            cancellationToken);
     }
+
+    private async Task<string?> Get(string requestUri, CancellationToken cancellationToken) =>
+        await httpClient.GetStringAsync(requestUri, cancellationToken);
 }

--- a/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
@@ -5,7 +5,7 @@ namespace WebApiGateway.Api.Clients;
 
 public class WasteObligationsProxy(HttpClient httpClient) : IWasteObligationsProxy
 {
-    public async Task<string?> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken)
+    public async Task<string?> GetComplianceDeclarations(int obligationYear, CancellationToken cancellationToken)
     {
         // See WasteObligationsAuthorisationHandler for :organisationId replacement 
         return await Get(

--- a/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
@@ -1,0 +1,11 @@
+﻿using WebApiGateway.Api.Clients.Interfaces;
+
+namespace WebApiGateway.Api.Clients;
+
+public class WasteObligationsProxy(HttpClient httpClient) : IWasteObligationsProxy
+{
+    public async Task<string?> Get(string requestUri, CancellationToken cancellationToken)
+    {
+        return await httpClient.GetStringAsync(requestUri, cancellationToken);
+    }
+}

--- a/WebApiGateway/WebApiGateway.Api/ConfigurationExtensions/HttpClientServiceCollectionExtensions.cs
+++ b/WebApiGateway/WebApiGateway.Api/ConfigurationExtensions/HttpClientServiceCollectionExtensions.cs
@@ -86,11 +86,7 @@ public static class HttpClientServiceCollectionExtensions
         return services;
     }
 
-    private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy() => HttpPolicyExtensions
-        .HandleTransientHttpError()
-        .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(3, retryAttempt)));
-
-    private static IServiceCollection AddWasteObligationsProxy(this IServiceCollection services)
+    public static IServiceCollection AddWasteObligationsProxy(this IServiceCollection services)
     {
         const string Name = WasteObligationsOptions.SectionName;
 
@@ -135,4 +131,8 @@ public static class HttpClientServiceCollectionExtensions
 
         return services;
     }
+
+    private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy() => HttpPolicyExtensions
+        .HandleTransientHttpError()
+        .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(3, retryAttempt)));
 }

--- a/WebApiGateway/WebApiGateway.Api/ConfigurationExtensions/HttpClientServiceCollectionExtensions.cs
+++ b/WebApiGateway/WebApiGateway.Api/ConfigurationExtensions/HttpClientServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.Extensions.Http;
@@ -80,10 +81,58 @@ public static class HttpClientServiceCollectionExtensions
             })
             .AddPolicyHandler(GetRetryPolicy());
 
+        services.AddWasteObligationsProxy();
+
         return services;
     }
 
     private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy() => HttpPolicyExtensions
         .HandleTransientHttpError()
         .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(3, retryAttempt)));
+
+    private static IServiceCollection AddWasteObligationsProxy(this IServiceCollection services)
+    {
+        const string Name = WasteObligationsOptions.SectionName;
+
+        services.AddOptions<WasteObligationsOptions>().BindConfiguration(Name);
+        services.AddOptions<HttpStandardResilienceOptions>(Name).BindConfiguration(Name);
+
+        services.AddHttpClient(nameof(OAuth2TokenCache));
+        services.AddKeyedSingleton<OAuth2TokenCache>(Name, (sp, _) =>
+            new OAuth2TokenCache(
+                sp.GetRequiredService<IHttpClientFactory>(),
+                sp.GetRequiredService<IOptions<WasteObligationsOptions>>().Value));
+        services.AddKeyedTransient<OAuth2Handler>(Name, (sp, _) =>
+            new OAuth2Handler(sp.GetRequiredKeyedService<OAuth2TokenCache>(Name)));
+        services.AddTransient<WasteObligationsAuthorisationHandler>();
+
+        var httpClientBuilder = services
+            .AddHttpClient<IWasteObligationsProxy, WasteObligationsProxy>()
+            .AddHttpMessageHandler(sp => sp.GetRequiredKeyedService<OAuth2Handler>(Name))
+            .AddHttpMessageHandler<WasteObligationsAuthorisationHandler>()
+            .ConfigureHttpClient(
+                (sp, httpClient) =>
+                {
+                    sp.GetRequiredService<IOptions<WasteObligationsOptions>>().Value.Configure(httpClient);
+
+                    // See resilience handler below for timeout control
+                    httpClient.Timeout = Timeout.InfiniteTimeSpan;
+                });
+
+        httpClientBuilder.AddResilienceHandler(
+            nameof(WasteObligationsOptions),
+            (builder, context) =>
+            {
+                var options = context
+                    .ServiceProvider.GetRequiredService<IOptionsMonitor<HttpStandardResilienceOptions>>()
+                    .Get(Name);
+
+                builder
+                    .AddTimeout(options.TotalRequestTimeout)
+                    .AddRetry(options.Retry)
+                    .AddTimeout(options.AttemptTimeout);
+            });
+
+        return services;
+    }
 }

--- a/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
+++ b/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
@@ -60,12 +60,15 @@ public class PrnController(IPrnService prnService, ILogger<PrnController> logger
 
     [HttpGet("prn/compliance-declarations")]
     [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken)
     {
-        var content = await wasteObligationsProxy.Get(
-            "/organisations/:organisationId/compliance-declarations?obligationYear=" + obligationYear,
-            cancellationToken);
-        
-        return Content(content, "application/json");
+        var content = await wasteObligationsProxy.GetComplianceDeclarations(obligationYear, cancellationToken);
+        if (content is not null)
+        {
+            return Content(content, "application/json");
+        }
+
+        return NotFound();
     }
 }

--- a/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
+++ b/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using WebApiGateway.Api.Attributes;
+using WebApiGateway.Api.Clients.Interfaces;
 using WebApiGateway.Api.Services.Interfaces;
 using WebApiGateway.Core.Models.Pagination;
 using WebApiGateway.Core.Models.Prns;
@@ -12,7 +13,7 @@ namespace WebApiGateway.Api.Controllers;
 [ApiVersion("1.0")]
 [Route("api/v{version:apiVersion}")]
 [ComplianceSchemeIdFilter]
-public class PrnController(IPrnService prnService, ILogger<PrnController> logger, IConfiguration config) : ControllerBase
+public class PrnController(IPrnService prnService, ILogger<PrnController> logger, IConfiguration config, IWasteObligationsProxy wasteObligationsProxy) : ControllerBase
 {
     private readonly string logPrefix = config["LogPrefix"];
 
@@ -55,5 +56,16 @@ public class PrnController(IPrnService prnService, ILogger<PrnController> logger
         logger.LogInformation("{Logprefix}: PrnController - UpdatePrnStatusToAccepted: Update Prn Satus for given Prns {Prns}", logPrefix, JsonConvert.SerializeObject(updatePrns));
         await prnService.UpdatePrnStatus(updatePrns);
         return NoContent();
+    }
+
+    [HttpGet("prn/compliance-declarations")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken)
+    {
+        var content = await wasteObligationsProxy.Get(
+            "/organisations/{organisationId}/compliance-declarations?obligationYear=" + obligationYear,
+            cancellationToken);
+        
+        return Content(content, "application/json");
     }
 }

--- a/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
+++ b/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
@@ -63,7 +63,7 @@ public class PrnController(IPrnService prnService, ILogger<PrnController> logger
     public async Task<IActionResult> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken)
     {
         var content = await wasteObligationsProxy.Get(
-            "/organisations/{organisationId}/compliance-declarations?obligationYear=" + obligationYear,
+            "/organisations/:organisationId/compliance-declarations?obligationYear=" + obligationYear,
             cancellationToken);
         
         return Content(content, "application/json");

--- a/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
+++ b/WebApiGateway/WebApiGateway.Api/Controllers/PrnController.cs
@@ -61,7 +61,7 @@ public class PrnController(IPrnService prnService, ILogger<PrnController> logger
     [HttpGet("prn/compliance-declarations")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> GetComplianceDeclarations(int? obligationYear, CancellationToken cancellationToken)
+    public async Task<IActionResult> GetComplianceDeclarations(int obligationYear, CancellationToken cancellationToken)
     {
         var content = await wasteObligationsProxy.GetComplianceDeclarations(obligationYear, cancellationToken);
         if (content is not null)

--- a/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2Handler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2Handler.cs
@@ -1,0 +1,17 @@
+﻿using System.Net.Http.Headers;
+
+namespace WebApiGateway.Api.Handlers;
+
+public class OAuth2Handler(OAuth2TokenCache tokenCache) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var token = await tokenCache.GetToken(cancellationToken);
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2Handler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2Handler.cs
@@ -1,7 +1,9 @@
-﻿using System.Net.Http.Headers;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Headers;
 
 namespace WebApiGateway.Api.Handlers;
 
+[ExcludeFromCodeCoverage]
 public class OAuth2Handler(OAuth2TokenCache tokenCache) : DelegatingHandler
 {
     protected override async Task<HttpResponseMessage> SendAsync(

--- a/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2Handler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2Handler.cs
@@ -1,9 +1,7 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using System.Net.Http.Headers;
+﻿using System.Net.Http.Headers;
 
 namespace WebApiGateway.Api.Handlers;
 
-[ExcludeFromCodeCoverage]
 public class OAuth2Handler(OAuth2TokenCache tokenCache) : DelegatingHandler
 {
     protected override async Task<HttpResponseMessage> SendAsync(

--- a/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2TokenCache.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2TokenCache.cs
@@ -3,6 +3,7 @@ using WebApiGateway.Core.Options;
 
 namespace WebApiGateway.Api.Handlers;
 
+[ExcludeFromCodeCoverage]
 public class OAuth2TokenCache(IHttpClientFactory httpClientFactory, OAuth2Options options)
 {
     private readonly SemaphoreSlim _semaphore = new(1, 1);

--- a/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2TokenCache.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2TokenCache.cs
@@ -1,0 +1,68 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using WebApiGateway.Core.Options;
+
+namespace WebApiGateway.Api.Handlers;
+
+public class OAuth2TokenCache(IHttpClientFactory httpClientFactory, OAuth2Options options)
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    private string? _accessToken;
+    private DateTime _expiresAt = DateTime.MinValue;
+
+    public async Task<string> GetToken(CancellationToken cancellationToken)
+    {
+        if (IsTokenValid())
+        {
+            return _accessToken;
+        }
+
+        await _semaphore.WaitAsync(cancellationToken);
+        try
+        {
+            if (IsTokenValid())
+            {
+                return _accessToken;
+            }
+
+            return await RefreshToken(cancellationToken);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+
+    private async Task<string> RefreshToken(CancellationToken cancellationToken)
+    {
+        var client = httpClientFactory.CreateClient(nameof(OAuth2TokenCache));
+        var values = new Dictionary<string, string>
+        {
+            ["grant_type"] = "client_credentials",
+            ["client_id"] = options.ClientId,
+            ["client_secret"] = options.ClientSecret,
+        };
+
+        if (options.Scope is not null)
+        {
+            values.Add("scope", options.Scope);
+        }
+
+        var body = new FormUrlEncodedContent(values);
+        var response = await client.PostAsync(options.TokenEndpoint, body, cancellationToken);
+
+        response.EnsureSuccessStatusCode();
+
+        var tokenResponse =
+            await response.Content.ReadFromJsonAsync<TokenResponse>(cancellationToken)
+            ?? throw new InvalidOperationException("Empty token response");
+
+        _expiresAt = DateTime.UtcNow.AddSeconds(tokenResponse.ExpiresIn - 60);
+        _accessToken = tokenResponse.AccessToken;
+
+        return _accessToken;
+    }
+    
+    [MemberNotNullWhen(true, nameof(_accessToken))]
+    private bool IsTokenValid() => _accessToken is not null && DateTime.UtcNow < _expiresAt;
+}

--- a/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2TokenCache.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/OAuth2TokenCache.cs
@@ -3,7 +3,6 @@ using WebApiGateway.Core.Options;
 
 namespace WebApiGateway.Api.Handlers;
 
-[ExcludeFromCodeCoverage]
 public class OAuth2TokenCache(IHttpClientFactory httpClientFactory, OAuth2Options options)
 {
     private readonly SemaphoreSlim _semaphore = new(1, 1);

--- a/WebApiGateway/WebApiGateway.Api/Handlers/TokenResponse.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/TokenResponse.cs
@@ -1,0 +1,12 @@
+﻿using System.Text.Json.Serialization;
+
+namespace WebApiGateway.Api.Handlers;
+
+public class TokenResponse
+{
+    [JsonPropertyName("access_token")]
+    public string AccessToken { get; init; }
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; init; }
+}

--- a/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
@@ -1,0 +1,24 @@
+﻿using WebApiGateway.Api.Clients.Interfaces;
+using WebApiGateway.Api.Extensions;
+
+namespace WebApiGateway.Api.Handlers;
+
+public class WasteObligationsAuthorisationHandler(IHttpContextAccessor httpContextAccessor, IAccountServiceClient accountServiceClient) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var userId = httpContextAccessor.HttpContext.User.UserId();
+        var organisationId = (await accountServiceClient.GetUserAccount(userId)).User.Organisations[0].Id;
+        
+        if (request.RequestUri.AbsolutePath.Contains("{organisationId}"))
+        {
+            var uriBuilder = new UriBuilder(request.RequestUri)
+            {
+                Path = request.RequestUri.AbsolutePath.Replace("{organisationId}", organisationId.ToString("D"))
+            };
+            request.RequestUri = uriBuilder.Uri;
+        }
+        
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
@@ -10,11 +10,11 @@ public class WasteObligationsAuthorisationHandler(IHttpContextAccessor httpConte
     {
         var organisationId = GetComplianceSchemeId() ?? await GetOrganisationIdFromUserFallback();
         
-        if (request.RequestUri.AbsolutePath.Contains("{organisationId}"))
+        if (request.RequestUri.AbsolutePath.Contains(":organisationId"))
         {
             var uriBuilder = new UriBuilder(request.RequestUri)
             {
-                Path = request.RequestUri.AbsolutePath.Replace("{organisationId}", organisationId.ToString("D"))
+                Path = request.RequestUri.AbsolutePath.Replace(":organisationId", organisationId.ToString("D"))
             };
             
             request.RequestUri = uriBuilder.Uri;

--- a/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
@@ -1,5 +1,6 @@
 ﻿using WebApiGateway.Api.Clients.Interfaces;
 using WebApiGateway.Api.Extensions;
+using WebApiGateway.Core.Constants;
 
 namespace WebApiGateway.Api.Handlers;
 
@@ -7,8 +8,7 @@ public class WasteObligationsAuthorisationHandler(IHttpContextAccessor httpConte
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var userId = httpContextAccessor.HttpContext.User.UserId();
-        var organisationId = (await accountServiceClient.GetUserAccount(userId)).User.Organisations[0].Id;
+        var organisationId = GetComplianceSchemeId() ?? await GetOrganisationIdFromUserFallback();
         
         if (request.RequestUri.AbsolutePath.Contains("{organisationId}"))
         {
@@ -16,9 +16,39 @@ public class WasteObligationsAuthorisationHandler(IHttpContextAccessor httpConte
             {
                 Path = request.RequestUri.AbsolutePath.Replace("{organisationId}", organisationId.ToString("D"))
             };
+            
             request.RequestUri = uriBuilder.Uri;
         }
         
         return await base.SendAsync(request, cancellationToken);
+    }
+
+    private async Task<Guid> GetOrganisationIdFromUserFallback()
+    {
+        var userId = httpContextAccessor.HttpContext.User.UserId();
+        var account = await accountServiceClient.GetUserAccount(userId);
+        
+        return account.User.Organisations[0].Id;
+    }
+
+    private Guid? GetComplianceSchemeId()
+    {
+        var context = httpContextAccessor.HttpContext;
+        if (context == null || !context.Items.TryGetValue(ComplianceScheme.ComplianceSchemeId, out var value))
+        {
+            return null;
+        }
+
+        if (value is Guid complianceSchemeId)
+        {
+            return complianceSchemeId;
+        }
+
+        if (value is string complianceSchemeIdString && Guid.TryParse(complianceSchemeIdString, out var parsedComplianceSchemeId))
+        {
+            return parsedComplianceSchemeId;
+        }
+
+        return null;
     }
 }

--- a/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
@@ -1,15 +1,14 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using WebApiGateway.Api.Clients.Interfaces;
+﻿using WebApiGateway.Api.Clients.Interfaces;
 using WebApiGateway.Api.Extensions;
 using WebApiGateway.Core.Constants;
 
 namespace WebApiGateway.Api.Handlers;
 
-[ExcludeFromCodeCoverage]
 public class WasteObligationsAuthorisationHandler(IHttpContextAccessor httpContextAccessor, IAccountServiceClient accountServiceClient) : DelegatingHandler
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
+        // Logic taken from PrnServiceClient.ConfigureHttpClientAsync
         var organisationId = GetComplianceSchemeId() ?? await GetOrganisationIdFromUserFallback();
         
         if (request.RequestUri.AbsolutePath.Contains(":organisationId"))

--- a/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
+++ b/WebApiGateway/WebApiGateway.Api/Handlers/WasteObligationsAuthorisationHandler.cs
@@ -1,9 +1,11 @@
-﻿using WebApiGateway.Api.Clients.Interfaces;
+﻿using System.Diagnostics.CodeAnalysis;
+using WebApiGateway.Api.Clients.Interfaces;
 using WebApiGateway.Api.Extensions;
 using WebApiGateway.Core.Constants;
 
 namespace WebApiGateway.Api.Handlers;
 
+[ExcludeFromCodeCoverage]
 public class WasteObligationsAuthorisationHandler(IHttpContextAccessor httpContextAccessor, IAccountServiceClient accountServiceClient) : DelegatingHandler
 {
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)

--- a/WebApiGateway/WebApiGateway.Api/Middleware/AuthLoggingMiddleware.cs
+++ b/WebApiGateway/WebApiGateway.Api/Middleware/AuthLoggingMiddleware.cs
@@ -1,0 +1,42 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace WebApiGateway.Api.Middleware;
+
+[ExcludeFromCodeCoverage]
+public class AuthLoggingMiddleware(RequestDelegate next, ILogger<AuthLoggingMiddleware> logger)
+{
+    public async Task Invoke(HttpContext context)
+    {
+        var request = context.Request;
+
+        logger.LogInformation("Auth Request Path: {Path}", request.Path);
+
+        foreach (var header in request.Headers)
+        {
+            logger.LogInformation("Header: {Key} {Value}", header.Key, header.Value.FirstOrDefault());
+        }
+
+        await next(context);
+
+        var user = context.User;
+
+        logger.LogInformation("IsAuthenticated: {IsAuth}", user.Identity?.IsAuthenticated);
+        logger.LogInformation("AuthType: {AuthType}", user.Identity?.AuthenticationType);
+
+        if (user.Identity?.IsAuthenticated == true)
+        {
+            foreach (var claim in user.Claims)
+            {
+                logger.LogInformation("Claim: {Type} = {Value}", claim.Type, claim.Value);
+            }
+        }
+
+        var endpoint = context.GetEndpoint();
+        var authData = endpoint?.Metadata.GetMetadata<Microsoft.AspNetCore.Authorization.IAuthorizeData>();
+
+        if (authData != null)
+        {
+            logger.LogInformation("Endpoint requires authorization policy: {Policy}", authData.Policy);
+        }
+    }
+}

--- a/WebApiGateway/WebApiGateway.Api/Middleware/RequestLoggingMiddleware.cs
+++ b/WebApiGateway/WebApiGateway.Api/Middleware/RequestLoggingMiddleware.cs
@@ -3,7 +3,7 @@
 namespace WebApiGateway.Api.Middleware;
 
 [ExcludeFromCodeCoverage]
-public class AuthLoggingMiddleware(RequestDelegate next, ILogger<AuthLoggingMiddleware> logger)
+public class RequestLoggingMiddleware(RequestDelegate next, ILogger<RequestLoggingMiddleware> logger)
 {
     public async Task Invoke(HttpContext context)
     {

--- a/WebApiGateway/WebApiGateway.Api/Program.cs
+++ b/WebApiGateway/WebApiGateway.Api/Program.cs
@@ -64,9 +64,9 @@ if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
     app.UseSwaggerUI();
+    app.UseMiddleware<RequestLoggingMiddleware>();
 }
 
-app.UseMiddleware<AuthLoggingMiddleware>();
 app.UseAuthentication();
 app.UseHttpsRedirection();
 app.UseAuthorization();

--- a/WebApiGateway/WebApiGateway.Api/Program.cs
+++ b/WebApiGateway/WebApiGateway.Api/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.Identity.Web;
 using Microsoft.OpenApi.Models;
 using WebApiGateway.Api.ConfigurationExtensions;
 using WebApiGateway.Api.HealthChecks;
+using WebApiGateway.Api.Middleware;
 using WebApiGateway.Api.Swagger;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -65,6 +66,7 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+app.UseMiddleware<AuthLoggingMiddleware>();
 app.UseAuthentication();
 app.UseHttpsRedirection();
 app.UseAuthorization();

--- a/WebApiGateway/WebApiGateway.Api/appsettings.json
+++ b/WebApiGateway/WebApiGateway.Api/appsettings.json
@@ -58,5 +58,11 @@
   "Redis": {
     "ConnectionString": "",
     "TimeToLiveInMinutes": 720
+  },
+  "WasteObligations": {
+    "TokenEndpoint": "http://localhost:9090/oauth2/v2.0/token",
+    "ClientId": "client_id",
+    "ClientSecret": "client_secret",
+    "BaseAddress": "http://localhost:9090/"
   }
 }

--- a/WebApiGateway/WebApiGateway.Core/Options/OAuth2Options.cs
+++ b/WebApiGateway/WebApiGateway.Core/Options/OAuth2Options.cs
@@ -1,0 +1,12 @@
+﻿namespace WebApiGateway.Core.Options;
+
+public class OAuth2Options
+{
+    public string TokenEndpoint { get; init; }
+
+    public string ClientId { get; init; }
+
+    public string ClientSecret { get; init; }
+
+    public string? Scope { get; init; }
+}

--- a/WebApiGateway/WebApiGateway.Core/Options/WasteObligationsOptions.cs
+++ b/WebApiGateway/WebApiGateway.Core/Options/WasteObligationsOptions.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+
+namespace WebApiGateway.Core.Options;
+
+public class WasteObligationsOptions : OAuth2Options
+{
+    public const string SectionName = "WasteObligations";
+
+    public string BaseAddress { get; init; }
+
+    public void Configure(HttpClient httpClient)
+    {
+        httpClient.BaseAddress = new Uri(BaseAddress);
+
+        if (httpClient.BaseAddress.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+        {
+            httpClient.DefaultRequestVersion = HttpVersion.Version20;
+        }
+    }
+}

--- a/WebApiGateway/WebApiGateway.Core/WebApiGateway.Core.csproj
+++ b/WebApiGateway/WebApiGateway.Core/WebApiGateway.Core.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="EPR.Common.Functions" Version="1.0.22" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
 </Project>

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
@@ -1,0 +1,59 @@
+﻿using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using WebApiGateway.Api.Clients;
+using WebApiGateway.Api.Clients.Interfaces;
+using WebApiGateway.Api.Handlers;
+using WebApiGateway.Core.Constants;
+
+namespace WebApiGateway.UnitTests.Api.Clients;
+
+[TestClass]
+public class WasteObligationsProxyTests
+{
+    [TestMethod]
+    public async Task Get_ShouldReplaceOrganisationIdInPath()
+    {
+        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        var httpContext = new DefaultHttpContext();
+        var complianceSchemeId = new Guid("af994ed9-2845-4047-9280-d96c4ea8eff2");
+        httpContext.Items.Add(ComplianceScheme.ComplianceSchemeId, complianceSchemeId);
+        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+        var fixtureHandler = new FixtureHandler();
+        
+        var services = new ServiceCollection();
+        services.AddTransient<WasteObligationsAuthorisationHandler>();
+        services.AddTransient(_ => fixtureHandler);
+        services.AddTransient(_ => new Mock<IAccountServiceClient>().Object);
+        services.AddTransient(_ => mockHttpContextAccessor.Object);
+        services
+            .AddHttpClient<IWasteObligationsProxy, WasteObligationsProxy>()
+            .AddHttpMessageHandler<WasteObligationsAuthorisationHandler>()
+            .AddHttpMessageHandler<FixtureHandler>()
+            .ConfigureHttpClient(httpClient => httpClient.BaseAddress = new Uri("http://localhost"));
+
+        var sp = services.BuildServiceProvider();
+        var proxy = sp.GetRequiredService<IWasteObligationsProxy>();
+        
+        var act = () => proxy.Get(
+            "/organisations/:organisationId/compliance-declarations?obligationYear=2026",
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<HttpRequestException>();
+        fixtureHandler.RequestUri?.AbsolutePath.Should().Contain(complianceSchemeId.ToString("D"));
+    }
+
+    private class FixtureHandler : DelegatingHandler
+    {
+        public Uri? RequestUri { get; private set; }
+        
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUri = request.RequestUri;
+            
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+}

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
@@ -94,6 +94,23 @@ public class WasteObligationsProxyTests
     }
     
     [TestMethod]
+    public async Task GetComplianceDeclarations_WhenComplianceDeclarationsNotFound_ShouldReturnNull()
+    {
+        HttpContext.Items.Add(ComplianceScheme.ComplianceSchemeId, ComplianceSchemeId);
+        await using var sp = Services.BuildServiceProvider();
+
+        var service = sp.GetRequiredService<IWasteObligationsProxy>();
+        const int ObligationYear = 2026;
+        const string AccessToken = "access_token";
+
+        WireMock.StubTokenRequest(accessToken: AccessToken);
+
+        var result = await service.GetComplianceDeclarations(ObligationYear, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+    
+    [TestMethod]
     public async Task GetComplianceDeclarations_WhenFallingBackToAccountService_ShouldReturnData()
     {
         HttpContext.Items.Add(ComplianceScheme.ComplianceSchemeId, string.Empty);

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
@@ -1,59 +1,130 @@
-﻿using FluentAssertions;
+﻿using System.Security.Claims;
+using FluentAssertions;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Identity.Web;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
-using WebApiGateway.Api.Clients;
 using WebApiGateway.Api.Clients.Interfaces;
-using WebApiGateway.Api.Handlers;
+using WebApiGateway.Api.ConfigurationExtensions;
 using WebApiGateway.Core.Constants;
+using WebApiGateway.Core.Models.UserAccount;
+using WebApiGateway.Core.Options;
+using WebApiGateway.UnitTests.Support;
+using WebApiGateway.UnitTests.Support.Extensions;
+using WireMock.Server;
 
 namespace WebApiGateway.UnitTests.Api.Clients;
 
 [TestClass]
 public class WasteObligationsProxyTests
 {
-    [TestMethod]
-    public async Task Get_ShouldReplaceOrganisationIdInPath()
+    private WireMockServer WireMock { get; set; }
+    private WireMockContext Context { get; set; }
+    private ServiceCollection Services { get; set; }
+    private Mock<IHttpContextAccessor> MockHttpContextAccessor { get; set; }
+    private Mock<IAccountServiceClient> MockAccountServiceClient { get; set; }
+    private DefaultHttpContext HttpContext { get; set; }
+    private Guid ComplianceSchemeId { get; } = new("af994ed9-2845-4047-9280-d96c4ea8eff2");
+
+    [TestInitialize]
+    public void TestInitialize()
     {
-        var mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
-        var httpContext = new DefaultHttpContext();
-        var complianceSchemeId = new Guid("af994ed9-2845-4047-9280-d96c4ea8eff2");
-        httpContext.Items.Add(ComplianceScheme.ComplianceSchemeId, complianceSchemeId);
-        mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
-        var fixtureHandler = new FixtureHandler();
+        var context = new WireMockContext();
         
-        var services = new ServiceCollection();
-        services.AddTransient<WasteObligationsAuthorisationHandler>();
-        services.AddTransient(_ => fixtureHandler);
-        services.AddTransient(_ => new Mock<IAccountServiceClient>().Object);
-        services.AddTransient(_ => mockHttpContextAccessor.Object);
-        services
-            .AddHttpClient<IWasteObligationsProxy, WasteObligationsProxy>()
-            .AddHttpMessageHandler<WasteObligationsAuthorisationHandler>()
-            .AddHttpMessageHandler<FixtureHandler>()
-            .ConfigureHttpClient(httpClient => httpClient.BaseAddress = new Uri("http://localhost"));
-
-        var sp = services.BuildServiceProvider();
-        var proxy = sp.GetRequiredService<IWasteObligationsProxy>();
+        WireMock = context.Server;
+        WireMock.Reset();
+        Context = context;
         
-        var act = () => proxy.Get(
-            "/organisations/:organisationId/compliance-declarations?obligationYear=2026",
-            CancellationToken.None);
-
-        await act.Should().ThrowAsync<HttpRequestException>();
-        fixtureHandler.RequestUri?.AbsolutePath.Should().Contain(complianceSchemeId.ToString("D"));
-    }
-
-    private class FixtureHandler : DelegatingHandler
-    {
-        public Uri? RequestUri { get; private set; }
-        
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        var config = new Dictionary<string, string?>
         {
-            RequestUri = request.RequestUri;
-            
-            return base.SendAsync(request, cancellationToken);
-        }
+            { $"{WasteObligationsOptions.SectionName}:BaseAddress", context.BaseAddress },
+            { $"{WasteObligationsOptions.SectionName}:TokenEndpoint", $"{context.BaseAddress}/token" },
+            { $"{WasteObligationsOptions.SectionName}:ClientId", "client_id" },
+            { $"{WasteObligationsOptions.SectionName}:ClientSecret", "client_secret" },
+            { $"{WasteObligationsOptions.SectionName}:Scope", "scope" },
+            { $"{WasteObligationsOptions.SectionName}:TotalRequestTimeout:Timeout", "00:00:40" },
+            { $"{WasteObligationsOptions.SectionName}:AttemptTimeout:Timeout", "00:00:05" },
+        };
+
+        Services = [];
+        Services.AddWasteObligationsProxy();
+        Services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection(config).Build());
+
+        MockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+        MockAccountServiceClient = new Mock<IAccountServiceClient>();
+        HttpContext = new DefaultHttpContext();
+        MockHttpContextAccessor.Setup(x => x.HttpContext).Returns(HttpContext);
+        
+        Services.AddTransient(_ => MockHttpContextAccessor.Object);
+        Services.AddTransient(_ => MockAccountServiceClient.Object);
+    }
+    
+    [TestMethod]
+    public async Task RequiredService_ShouldNotBeNull()
+    {
+        await using var sp = Services.BuildServiceProvider();
+
+        var service = sp.GetService<IWasteObligationsProxy>();
+
+        service.Should().NotBeNull();
+    }
+    
+    [DataTestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public async Task GetComplianceDeclarations_WhenUsingHeader_ShouldReturnData(bool toString)
+    {
+        HttpContext.Items.Add(
+            ComplianceScheme.ComplianceSchemeId,
+            toString ? ComplianceSchemeId.ToString("D") : ComplianceSchemeId);
+        await using var sp = Services.BuildServiceProvider();
+
+        var service = sp.GetRequiredService<IWasteObligationsProxy>();
+        const int ObligationYear = 2026;
+        const string AccessToken = "access_token";
+
+        WireMock.StubTokenRequest(accessToken: AccessToken);
+        WireMock.StubWasteObligationsComplianceDeclarationsRequest(ComplianceSchemeId, ObligationYear, AccessToken);
+
+        var result = await service.GetComplianceDeclarations(ObligationYear, CancellationToken.None);
+
+        result.Should().NotBeNull();
+    }
+    
+    [TestMethod]
+    public async Task GetComplianceDeclarations_WhenFallingBackToAccountService_ShouldReturnData()
+    {
+        HttpContext.Items.Add(ComplianceScheme.ComplianceSchemeId, string.Empty);
+        var userId = Guid.NewGuid();
+        var organisationId = Guid.NewGuid();
+        HttpContext.User =
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimConstants.ObjectId, userId.ToString("D"))]));
+        MockAccountServiceClient.Setup(x => x.GetUserAccount(userId)).ReturnsAsync(new UserAccount
+        {
+            User = new UserDetails
+            {
+                Organisations =
+                [
+                    new OrganisationDetail
+                    {
+                        Id = organisationId
+                    }
+                ]
+            }
+        });
+        await using var sp = Services.BuildServiceProvider();
+
+        var service = sp.GetRequiredService<IWasteObligationsProxy>();
+        const int ObligationYear = 2026;
+        const string AccessToken = "access_token";
+
+        WireMock.StubTokenRequest(accessToken: AccessToken);
+        WireMock.StubWasteObligationsComplianceDeclarationsRequest(organisationId, ObligationYear, AccessToken);
+
+        var result = await service.GetComplianceDeclarations(ObligationYear, CancellationToken.None);
+
+        result.Should().NotBeNull();
     }
 }

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/PrnControllerTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/PrnControllerTests.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using WebApiGateway.Api.Clients.Interfaces;
 using WebApiGateway.Api.Controllers;
 using WebApiGateway.Api.Services.Interfaces;
 using WebApiGateway.Core.Models.Pagination;
@@ -19,6 +20,7 @@ public class PrnControllerTests
     private Mock<ILogger<PrnController>> _loggerMock;
     private Mock<IPrnService> _prnService;
     private Mock<IConfiguration> _configuration;
+    private Mock<IWasteObligationsProxy> _wasteObligationsProxy;
     private PrnController _systemUnderTest;
 
     [TestInitialize]
@@ -27,7 +29,8 @@ public class PrnControllerTests
         _loggerMock = new Mock<ILogger<PrnController>>();
         _prnService = new Mock<IPrnService>();
         _configuration = new Mock<IConfiguration>();
-        _systemUnderTest = new PrnController(_prnService.Object, _loggerMock.Object, _configuration.Object);
+        _wasteObligationsProxy = new Mock<IWasteObligationsProxy>();
+        _systemUnderTest = new PrnController(_prnService.Object, _loggerMock.Object, _configuration.Object, _wasteObligationsProxy.Object);
     }
 
     [TestMethod]

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/PrnControllerTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/PrnControllerTests.cs
@@ -119,4 +119,17 @@ public class PrnControllerTests
         Func<Task> act = async () => await _systemUnderTest.UpdatePrnStatusToAccepted(updatePrns);
         await act.Should().ThrowAsync<Exception>().WithMessage("Update failed");
     }
+
+    [TestMethod]
+    public async Task GetComplianceDeclarations_ReturnsOk()
+    {
+        _wasteObligationsProxy.Setup(x => x.Get(
+            "/organisations/:organisationId/compliance-declarations?obligationYear=2026",
+            CancellationToken.None)).ReturnsAsync("{}");
+
+        var result = await _systemUnderTest.GetComplianceDeclarations(2026, CancellationToken.None);
+
+        result.Should().BeOfType<ContentResult>().Which.Content.Should().Be("{}");
+        result.Should().BeOfType<ContentResult>().Which.ContentType.Should().Be("application/json");
+    }
 }

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/PrnControllerTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Controllers/PrnControllerTests.cs
@@ -119,13 +119,21 @@ public class PrnControllerTests
         Func<Task> act = async () => await _systemUnderTest.UpdatePrnStatusToAccepted(updatePrns);
         await act.Should().ThrowAsync<Exception>().WithMessage("Update failed");
     }
-
+    
     [TestMethod]
-    public async Task GetComplianceDeclarations_ReturnsOk()
+    public async Task GetComplianceDeclarations_ReturnsNotFound_WhenContentIsNull()
     {
-        _wasteObligationsProxy.Setup(x => x.Get(
-            "/organisations/:organisationId/compliance-declarations?obligationYear=2026",
-            CancellationToken.None)).ReturnsAsync("{}");
+        _wasteObligationsProxy.Setup(x => x.GetComplianceDeclarations(2026, CancellationToken.None)).ReturnsAsync((string?)null);
+
+        var result = await _systemUnderTest.GetComplianceDeclarations(2026, CancellationToken.None);
+
+        result.Should().BeOfType<NotFoundResult>();
+    }
+    
+    [TestMethod]
+    public async Task GetComplianceDeclarations_ReturnsOk_WhenContentIsNotNull()
+    {
+        _wasteObligationsProxy.Setup(x => x.GetComplianceDeclarations(2026, CancellationToken.None)).ReturnsAsync("{}");
 
         var result = await _systemUnderTest.GetComplianceDeclarations(2026, CancellationToken.None);
 

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Handlers/OAuth2HandlerTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Handlers/OAuth2HandlerTests.cs
@@ -1,0 +1,149 @@
+﻿using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebApiGateway.Api.Handlers;
+using WebApiGateway.Core.Options;
+using WebApiGateway.UnitTests.Support;
+using WebApiGateway.UnitTests.Support.Extensions;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace WebApiGateway.UnitTests.Api.Handlers;
+
+[TestClass]
+public class OAuth2HandlerTests
+{
+    private WireMockServer WireMock { get; set; }
+    private WireMockContext Context { get; set; }
+    
+    [TestInitialize]
+    public void TestInitialize()
+    {
+        var context = new WireMockContext();
+        
+        WireMock = context.Server;
+        WireMock.Reset();
+        Context = context;
+    }
+    
+    [DataTestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    public async Task WhenRequestsAreMade_ShouldGetTokenOnce(int requests)
+    {
+        const string AccessToken = nameof(AccessToken);
+        WireMock.StubTokenRequest(AccessToken);
+        WireMock
+            .Given(
+                Request.Create().UsingGet().WithPath("/endpoint").WithHeader("Authorization", $"Bearer {AccessToken}"))
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK));
+
+        var services = CreateServices();
+        await using var sp = services.BuildServiceProvider();
+
+        var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(OAuth2HandlerTests));
+
+        for (var i = 0; i < requests; i++)
+        {
+            var response = await client.GetAsync("/endpoint", CancellationToken.None);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/token").Should().Be(1);
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/endpoint").Should().Be(requests);
+    }
+
+    [TestMethod]
+    public async Task WhenConcurrentRequestsAreMade_ShouldGetTokenOnce()
+    {
+        const string AccessToken = nameof(AccessToken);
+        WireMock.StubTokenRequest(AccessToken);
+        WireMock
+            .Given(
+                Request.Create().UsingGet().WithPath("/endpoint").WithHeader("Authorization", $"Bearer {AccessToken}"))
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK));
+
+        var services = CreateServices();
+        await using var sp = services.BuildServiceProvider();
+
+        var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(OAuth2HandlerTests));
+
+        var request1 = client.GetAsync("/endpoint", CancellationToken.None);
+        var request2 = client.GetAsync("/endpoint", CancellationToken.None);
+
+        await Task.WhenAll(request1, request2);
+
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/token").Should().Be(1);
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/endpoint").Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task WhenTokenExpires_ShouldGetTokenAgain()
+    {
+        const string AccessToken = nameof(AccessToken);
+        WireMock.StubTokenRequest(AccessToken, expiryInSeconds: 60);
+        WireMock
+            .Given(
+                Request.Create().UsingGet().WithPath("/endpoint").WithHeader("Authorization", $"Bearer {AccessToken}"))
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK));
+
+        var services = CreateServices();
+        await using var sp = services.BuildServiceProvider();
+
+        var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(OAuth2HandlerTests));
+
+        await client.GetAsync("/endpoint", CancellationToken.None);
+        await client.GetAsync("/endpoint", CancellationToken.None);
+
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/token").Should().Be(2);
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/endpoint").Should().Be(2);
+    }
+
+    [TestMethod]
+    public async Task WhenNoScope_ShouldNotSendScope()
+    {
+        const string AccessToken = nameof(AccessToken);
+        WireMock.StubTokenRequest(AccessToken, expiryInSeconds: 60, scope: null);
+        WireMock
+            .Given(
+                Request.Create().UsingGet().WithPath("/endpoint").WithHeader("Authorization", $"Bearer {AccessToken}"))
+            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.OK));
+
+        var services = CreateServices(scope: null);
+        await using var sp = services.BuildServiceProvider();
+
+        var client = sp.GetRequiredService<IHttpClientFactory>().CreateClient(nameof(OAuth2HandlerTests));
+
+        await client.GetAsync("/endpoint", CancellationToken.None);
+
+        WireMock
+            .LogEntries.Count(x =>
+                x.RequestMessage?.Path == "/token" && x.RequestMessage?.Body?.Contains("scope") is false)
+            .Should()
+            .Be(1);
+        WireMock.LogEntries.Count(x => x.RequestMessage?.Path == "/endpoint").Should().Be(1);
+    }
+
+    private ServiceCollection CreateServices(string? scope = "scope")
+    {
+        var result = new ServiceCollection();
+
+        result
+            .AddHttpClient(nameof(OAuth2HandlerTests))
+            .AddHttpMessageHandler(sp => new OAuth2Handler(
+                new OAuth2TokenCache(
+                    sp.GetRequiredService<IHttpClientFactory>(),
+                    new OAuth2Options
+                    {
+                        TokenEndpoint = Context.BaseAddress + "/token",
+                        ClientId = "client_id",
+                        ClientSecret = "client_secret",
+                        Scope = scope,
+                    })))
+            .ConfigureHttpClient(httpClient => httpClient.BaseAddress = new Uri(Context.BaseAddress));
+
+        return result;
+    }
+}

--- a/WebApiGateway/WebApiGateway.UnitTests/Core/Options/WasteObligationsOptionsTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Core/Options/WasteObligationsOptionsTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Net;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using WebApiGateway.Core.Options;
+
+namespace WebApiGateway.UnitTests.Core.Options;
+
+[TestClass]
+public class WasteObligationsOptionsTests
+{
+    [DataTestMethod]
+    [DataRow("http", 1)]
+    [DataRow("https", 2)]
+    public void WhenScheme_ShouldBeExpectedVersion(string scheme, int expectedVersion)
+    {
+        var subject = new WasteObligationsOptions
+        {
+            BaseAddress = $"{scheme}://waste-obligations",
+            TokenEndpoint = "http://oauth2/token",
+            ClientId = "client_id",
+            ClientSecret = "client_secret",
+        };
+
+        var client = new HttpClient();
+        subject.Configure(client);
+
+        switch (expectedVersion)
+        {
+            case 1:
+                client.DefaultRequestVersion.Should().Be(HttpVersion.Version11);
+                break;
+            case 2:
+                client.DefaultRequestVersion.Should().Be(HttpVersion.Version20);
+                break;
+        }
+    }
+}

--- a/WebApiGateway/WebApiGateway.UnitTests/Support/Extensions/OAuth2Extensions.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Support/Extensions/OAuth2Extensions.cs
@@ -1,0 +1,47 @@
+﻿using System.Net;
+using AnyOfTypes;
+using WireMock.Matchers;
+using WireMock.Models;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace WebApiGateway.UnitTests.Support.Extensions;
+
+public static class OAuth2Extensions
+{
+    public const string AccessToken = "access_token";
+
+    public static void StubTokenRequest(
+        this WireMockServer wireMock,
+        string accessToken = AccessToken,
+        int expiryInSeconds = 3600,
+        string? scope = "scope")
+    {
+        AnyOf<string, StringPattern>[] patterns =
+        [
+            "grant_type=client_credentials",
+            "client_id=client_id",
+            "client_secret=client_secret",
+        ];
+
+        if (scope is not null)
+        {
+            patterns = patterns.Append($"scope={scope}").ToArray();
+        }
+
+        wireMock
+            .Given(
+                Request
+                    .Create()
+                    .UsingPost()
+                    .WithPath("/token")
+                    .WithHeader("Content-Type", "application/x-www-form-urlencoded")
+                    .WithBody(new FormUrlEncodedMatcher(patterns, matchOperator: MatchOperator.And)))
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithBodyAsJson(new { access_token = accessToken, expires_in = expiryInSeconds }));
+    }
+}

--- a/WebApiGateway/WebApiGateway.UnitTests/Support/Extensions/WasteObligationsExtensions.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Support/Extensions/WasteObligationsExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System.Net;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace WebApiGateway.UnitTests.Support.Extensions;
+
+public static class WasteObligationsExtensions
+{
+    public static void StubWasteObligationsComplianceDeclarationsRequest(
+        this WireMockServer wireMock,
+        Guid organisationId,
+        int obligationYear = 2026,
+        string? accessToken = null)
+    {
+        var request = Request.Create().UsingGet()
+            .WithPath($"/organisations/{organisationId:D}/compliance-declarations")
+            .WithParam("obligationYear", obligationYear.ToString());
+
+        if (accessToken is not null)
+        {
+            request = request.WithHeader("Authorization", $"Bearer {accessToken}");
+        }
+
+        wireMock
+            .Given(request)
+            .RespondWith(
+                Response
+                    .Create()
+                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithBodyAsJson(new
+                    {
+                    }));
+    }
+}

--- a/WebApiGateway/WebApiGateway.UnitTests/Support/WireMockContext.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Support/WireMockContext.cs
@@ -1,0 +1,25 @@
+﻿using WireMock.Server;
+
+namespace WebApiGateway.UnitTests.Support;
+
+public class WireMockContext : IDisposable
+{
+    public WireMockContext()
+    {
+        Server = WireMockServer.Start();
+        BaseAddress = Server.Urls[0];
+        HttpClient = new HttpClient { BaseAddress = new Uri(BaseAddress) };
+    }
+    
+    public WireMockServer Server { get; }
+    public string BaseAddress { get; }
+    public HttpClient HttpClient { get; }
+
+    public void Dispose()
+    {
+        GC.SuppressFinalize(this);
+        Server.Stop();
+        Server.Dispose();
+        HttpClient.Dispose();
+    }
+}

--- a/WebApiGateway/WebApiGateway.UnitTests/WebApiGateway.UnitTests.csproj
+++ b/WebApiGateway/WebApiGateway.UnitTests/WebApiGateway.UnitTests.csproj
@@ -23,20 +23,17 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="WireMock.Net" Version="2.3.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\WebApiGateway.Api\WebApiGateway.Api.csproj" />
     <ProjectReference Include="..\WebApiGateway.Core\WebApiGateway.Core.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Support\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR introduces a proxy to the `waste-obligations` service running in CDP. OAuth2 creds are needed and can be configured and a new endpoint is available at:

```
GET /api/v1/prn/compliance-declarations?obligationYear={year}
{
  "complianceDeclarations": [
    {
      "id": "b5aa3ef6-e7d5-4eb2-acea-589573d5a005",
      "created": "2026-04-27T14:00:00+00:00",
      "updated": "2026-04-27T14:00:00+00:00",
      "status": "Submitted",
      "organisationId": "923fa611-571c-4948-ab7d-fbb75e75ed65",
      "obligationYear": 2026,
      "obligations": [
        {
          "material": "Plastic",
          "recyclingTarget": 0.75,
          "tonnages": {
            "material": 100,
            "awaitingAcceptance": 10,
            "accepted": 2,
            "outstanding": 20,
            "obligated": 5
          },
          "status": "NoDataYet"
        }
      ],
      "declarationText": {
        "text": "This is the text",
        "language": "en"
      },
      "submitterName": "Submitter Name",
      "user": {
        "id": "e72be574-8b5b-4836-af47-dd7e0c0d1d87",
        "email": "submitter@email.com"
      }
    },
    {
      "id": "41095a7f-3896-4347-b367-136f94725883",
      "created": "2026-04-26T14:00:00+00:00",
      "updated": "2026-04-26T14:00:00+00:00",
      "status": "Submitted",
      "organisationId": "923fa611-571c-4948-ab7d-fbb75e75ed65",
      "obligationYear": 2026,
      "obligations": [
        {
          "material": "Plastic",
          "recyclingTarget": 0.75,
          "tonnages": {
            "material": 100,
            "awaitingAcceptance": 10,
            "accepted": 2,
            "outstanding": 20,
            "obligated": 5
          },
          "status": "NoDataYet"
        }
      ],
      "declarationText": {
        "text": "This is the text",
        "language": "en"
      },
      "submitterName": "Submitter Name",
      "user": {
        "id": "e72be574-8b5b-4836-af47-dd7e0c0d1d87",
        "email": "submitter@email.com"
      }
    }
  ]
}
```

There are no types for this response structure defined in the gateway, we just send back whatever the `waste-obligations` has given us.