### PR TITLE
MO-168: Bubble up any downstream errors

### DIFF
--- a/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
+++ b/WebApiGateway/WebApiGateway.Api/Clients/WasteObligationsProxy.cs
@@ -21,6 +21,8 @@ public class WasteObligationsProxy(HttpClient httpClient) : IWasteObligationsPro
             return null;
         }
 
+        response.EnsureSuccessStatusCode();
+
         return await response.Content.ReadAsStringAsync(cancellationToken);
     }
 }

--- a/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Api/Clients/WasteObligationsProxyTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Security.Claims;
+﻿using System.Net;
+using System.Security.Claims;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
@@ -108,6 +109,24 @@ public class WasteObligationsProxyTests
         var result = await service.GetComplianceDeclarations(ObligationYear, CancellationToken.None);
 
         result.Should().BeNull();
+    }
+    
+    [TestMethod]
+    public async Task GetComplianceDeclarations_WhenUnsuccessful_ShouldThrow()
+    {
+        HttpContext.Items.Add(ComplianceScheme.ComplianceSchemeId, ComplianceSchemeId);
+        await using var sp = Services.BuildServiceProvider();
+
+        var service = sp.GetRequiredService<IWasteObligationsProxy>();
+        const int ObligationYear = 2026;
+        const string AccessToken = "access_token";
+
+        WireMock.StubTokenRequest(accessToken: AccessToken);
+        WireMock.StubWasteObligationsComplianceDeclarationsRequest(ComplianceSchemeId, ObligationYear, AccessToken, HttpStatusCode.Forbidden);
+
+        var act = () => service.GetComplianceDeclarations(ObligationYear, CancellationToken.None);
+
+        act.Should().ThrowAsync<HttpRequestException>();
     }
     
     [TestMethod]

--- a/WebApiGateway/WebApiGateway.UnitTests/Support/Extensions/WasteObligationsExtensions.cs
+++ b/WebApiGateway/WebApiGateway.UnitTests/Support/Extensions/WasteObligationsExtensions.cs
@@ -11,7 +11,8 @@ public static class WasteObligationsExtensions
         this WireMockServer wireMock,
         Guid organisationId,
         int obligationYear = 2026,
-        string? accessToken = null)
+        string? accessToken = null,
+        HttpStatusCode? statusCode = null)
     {
         var request = Request.Create().UsingGet()
             .WithPath($"/organisations/{organisationId:D}/compliance-declarations")
@@ -27,7 +28,7 @@ public static class WasteObligationsExtensions
             .RespondWith(
                 Response
                     .Create()
-                    .WithStatusCode(HttpStatusCode.OK)
+                    .WithStatusCode(statusCode ?? HttpStatusCode.OK)
                     .WithBodyAsJson(new
                     {
                     }));


### PR DESCRIPTION
Instead of overthinking the response and handling specific HTTP codes, this PR just ensures the downstream call was successful and if it wasn't, it will throw.